### PR TITLE
feat(git): Allow reading files from git tags

### DIFF
--- a/src/Extensions.Statiq.Git.Test/GitTestBase.cs
+++ b/src/Extensions.Statiq.Git.Test/GitTestBase.cs
@@ -44,6 +44,23 @@ namespace Grynwald.Extensions.Statiq.Git.Test
             return new GitId(commitId);
         }
 
+        protected GitTag GitTag(string name, GitId? target = null)
+        {
+            if (target is null)
+            {
+                Git($"tag {name}");
+            }
+            else
+            {
+                Git($"tag {name} {target}");
+            }
+
+            Git($"rev-parse --short {name}", out var commitId);
+            commitId = commitId.Trim();
+
+            return new GitTag(name, new GitId(commitId));
+        }
+
         protected void Git(string command) => Git(command, out _, out _);
 
         protected void Git(string command, out string stdOut) => Git(command, out stdOut, out _);

--- a/src/Extensions.Statiq.Git.Test/Internal/GitDirectoryInfoTest.cs
+++ b/src/Extensions.Statiq.Git.Test/Internal/GitDirectoryInfoTest.cs
@@ -24,7 +24,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
         {
             using var repository = new Repository(m_WorkingDirectory);
 
-            var sut = new GitDirectoryInfo(repository.Head.Tip.Tree);
+            var sut = new GitDirectoryInfo(repository.Head.Tip);
 
             sut.Name.Should().Be("");
             sut.FullName.Should().Be("");
@@ -40,8 +40,9 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
         public void Constructor_throws_ArgumentException_for_invalid_names(string name)
         {
             using var repository = new Repository(m_WorkingDirectory);
+            var root = new GitDirectoryInfo(repository.Head.Tip);
 
-            Action act = () => new GitDirectoryInfo(name, new GitDirectoryInfo(repository.Head.Tip.Tree), repository.Head.Tip.Tree);
+            Action act = () => new GitDirectoryInfo(root.Commit, name, root, repository.Head.Tip.Tree);
             act.Should().Throw<ArgumentException>();
         }
 
@@ -49,13 +50,14 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
         public void Constructor_throws_ArgumentException_if_parent_is_null()
         {
             using var repository = new Repository(m_WorkingDirectory);
+            var commitId = repository.Head.Tip.GetGitId();
 
-            Action act = () => new GitDirectoryInfo("dir", null!, repository.Head.Tip.Tree);
+            Action act = () => new GitDirectoryInfo(commitId, "dir", null!, repository.Head.Tip.Tree);
             act.Should().Throw<ArgumentNullException>();
         }
 
         [Test]
-        public void Constructor_throws_ArgumentException_if_tree_of_root_directory_is_null()
+        public void Constructor_throws_ArgumentException_if_Commit_is_null()
         {
             Action act = () => new GitDirectoryInfo(null!);
             act.Should().Throw<ArgumentNullException>();
@@ -65,8 +67,9 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
         public void Constructor_throws_ArgumentException_if_tree_is_null()
         {
             using var repository = new Repository(m_WorkingDirectory);
+            var root = new GitDirectoryInfo(repository.Head.Tip);
 
-            Action act = () => new GitDirectoryInfo("dir", new GitDirectoryInfo(repository.Head.Tip.Tree), null!);
+            Action act = () => new GitDirectoryInfo(root.Commit, "dir", root, null!);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -75,7 +78,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
         {
             using var repository = new Repository(m_WorkingDirectory);
 
-            var sut = new GitDirectoryInfo(repository.Head.Tip.Tree);
+            var sut = new GitDirectoryInfo(repository.Head.Tip);
 
             sut.EnumerateFileSystemInfos()
                 .Should().NotBeNull()
@@ -104,7 +107,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
             using var repository = new Repository(m_WorkingDirectory);
 
             // ACT
-            var sut = new GitDirectoryInfo(repository.Head.Tip.Tree);
+            var sut = new GitDirectoryInfo(repository.Head.Tip);
             var fileSystemInfos = sut.EnumerateFileSystemInfos();
 
             // ASSERT
@@ -144,7 +147,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
             using var repository = new Repository(m_WorkingDirectory);
 
             // ACT
-            var sut = new GitDirectoryInfo(repository.Head.Tip.Tree);
+            var sut = new GitDirectoryInfo(repository.Head.Tip);
 
             // ASSERT
             sut.GetDirectory(path)
@@ -160,7 +163,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
         {
             // ARRANGE            
             using var repository = new Repository(m_WorkingDirectory);
-            var sut = new GitDirectoryInfo(repository.Head.Tip.Tree);
+            var sut = new GitDirectoryInfo(repository.Head.Tip);
 
             // ACT
             var dir = sut.GetDirectory(path);
@@ -198,7 +201,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
             using var repository = new Repository(m_WorkingDirectory);
 
             // ACT
-            var sut = new GitDirectoryInfo(repository.Head.Tip.Tree);
+            var sut = new GitDirectoryInfo(repository.Head.Tip);
 
             // ASSERT
             sut.GetFile(path)
@@ -218,7 +221,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
         {
             // ARRANGE            
             using var repository = new Repository(m_WorkingDirectory);
-            var sut = new GitDirectoryInfo(repository.Head.Tip.Tree);
+            var sut = new GitDirectoryInfo(repository.Head.Tip);
 
             // ACT
             var file = sut.GetFile(path);

--- a/src/Extensions.Statiq.Git.Test/Internal/GitFileInfoTest.cs
+++ b/src/Extensions.Statiq.Git.Test/Internal/GitFileInfoTest.cs
@@ -35,7 +35,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
             using var repository = new Repository(m_WorkingDirectory);
             var blob = (Blob)repository.Head.Tip.Tree.First(x => x.Name == "file1.txt").Target;
 
-            Action act = () => new GitFileInfo(name, new GitDirectoryInfo(repository.Head.Tip.Tree), blob);
+            Action act = () => new GitFileInfo(name, new GitDirectoryInfo(repository.Head.Tip), blob);
             act.Should().Throw<ArgumentException>();
         }
 
@@ -59,7 +59,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
         {
             using var repository = new Repository(m_WorkingDirectory);
 
-            Action act = () => new GitFileInfo("file", new GitDirectoryInfo(repository.Head.Tip.Tree), null!);
+            Action act = () => new GitFileInfo("file", new GitDirectoryInfo(repository.Head.Tip), null!);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -74,7 +74,7 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
 
             using var repository = new Repository(m_WorkingDirectory);
             var blob = (Blob)repository.Head.Tip.Tree.First(x => x.Name == "file1.txt").Target;
-            var sut = new GitFileInfo("file1.txt", new GitDirectoryInfo(repository.Head.Tip.Tree), blob);
+            var sut = new GitFileInfo("file1.txt", new GitDirectoryInfo(repository.Head.Tip), blob);
 
             // ACT
             using var contentStream = sut.GetContentStream();

--- a/src/Extensions.Statiq.Git.Test/Internal/GitRepositoryTest.cs
+++ b/src/Extensions.Statiq.Git.Test/Internal/GitRepositoryTest.cs
@@ -189,8 +189,8 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
             _ = GitCommit(allowEmtpy: true);
             var commit3 = GitCommit(allowEmtpy: true);
 
-            Git($"tag my-tag-1 {commit1}");
-            Git($"tag my-tag-2 {commit3}");
+            var tag1 = GitTag("my-tag-1", commit1);
+            var tag2 = GitTag("my-tag-2", commit3);
 
             using var sut = CreateInstance(m_WorkingDirectory);
 
@@ -201,8 +201,8 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
             tags
                 .Should().NotBeNull()
                 .And.HaveCount(2)
-                .And.Contain(new GitTag("my-tag-1", commit1))
-                .And.Contain(new GitTag("my-tag-2", commit3));
+                .And.Contain(tag1)
+                .And.Contain(tag2);
         }
 
     }

--- a/src/Extensions.Statiq.Git.Test/Internal/GitRepositoryTest.cs
+++ b/src/Extensions.Statiq.Git.Test/Internal/GitRepositoryTest.cs
@@ -164,5 +164,46 @@ namespace Grynwald.Extensions.Statiq.Git.Test.Internal
             // ASSERT
             currentBranch.Should().Be("my-default-branch");
         }
+
+        [Test]
+        public void Tags_returns_empty_enumerable_if_there_are_no_tags()
+        {
+            // ARRANGE
+            GitCommit(allowEmtpy: true);
+
+            using var sut = CreateInstance(m_WorkingDirectory);
+
+            // ACT
+            var tags = sut.Tags;
+
+            // ASSERT
+            tags.Should().NotBeNull().And.BeEmpty();
+        }
+
+
+        [Test]
+        public void Tags_returns_expected_tags()
+        {
+            // ARRANGE
+            var commit1 = GitCommit(allowEmtpy: true);
+            _ = GitCommit(allowEmtpy: true);
+            var commit3 = GitCommit(allowEmtpy: true);
+
+            Git($"tag my-tag-1 {commit1}");
+            Git($"tag my-tag-2 {commit3}");
+
+            using var sut = CreateInstance(m_WorkingDirectory);
+
+            // ACT
+            var tags = sut.Tags;
+
+            // ASSERT
+            tags
+                .Should().NotBeNull()
+                .And.HaveCount(2)
+                .And.Contain(new GitTag("my-tag-1", commit1))
+                .And.Contain(new GitTag("my-tag-2", commit3));
+        }
+
     }
 }

--- a/src/Extensions.Statiq.Git.Test/Internal/GitTagTest.cs
+++ b/src/Extensions.Statiq.Git.Test/Internal/GitTagTest.cs
@@ -1,0 +1,39 @@
+﻿//Note: Adapted from https://github.com/ap0llo/changelog/blob/9c789d570199480801ea95d57f425b425b5f1964/src/ChangeLog.Test/Git/GitTagTest.cs
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Grynwald.Extensions.Statiq.Git.Internal;
+using NUnit.Framework;
+
+namespace Grynwald.Extensions.Statiq.Git.Test.Internal
+{
+    /// <summary>
+    /// Tests for <see cref="GitTag"/>
+    /// </summary>
+    public class GitTagTest : EqualityTest<GitTag, GitTagTest>, IEqualityTestDataProvider<GitTag>
+    {
+        public IEnumerable<(GitTag left, GitTag right)> GetEqualTestCases()
+        {
+            yield return (new GitTag("tag1", new GitId("abc123")), new GitTag("tag1", new GitId("abc123")));
+            yield return (new GitTag("tag1", new GitId("abc123")), new GitTag("tag1", new GitId("ABC123")));
+        }
+
+        public IEnumerable<(GitTag left, GitTag right)> GetUnequalTestCases()
+        {
+            yield return (new GitTag("tag1", new GitId("abc123")), new GitTag("tag2", new GitId("abc123")));
+            yield return (new GitTag("tag1", new GitId("abc123")), new GitTag("tag1", new GitId("def456")));
+        }
+
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("  ")]
+        [TestCase("\t")]
+        public void Name_must_not_be_null_or_whitespace(string name)
+        {
+            Action act = () => new GitTag(name, new GitId("abc123"));
+            act.Should().Throw<ArgumentException>();
+        }
+    }
+}

--- a/src/Extensions.Statiq.Git/GitKeys.cs
+++ b/src/Extensions.Statiq.Git/GitKeys.cs
@@ -4,6 +4,7 @@
     {
         public const string GitRepositoryUrl = nameof(GitRepositoryUrl);
         public const string GitBranch = nameof(GitBranch);
+        public const string GitTag = nameof(GitTag);
         public const string GitCommit = nameof(GitCommit);
         public const string GitRelativePath = nameof(GitRelativePath);
     }

--- a/src/Extensions.Statiq.Git/Internal/GitFileInfo.cs
+++ b/src/Extensions.Statiq.Git/Internal/GitFileInfo.cs
@@ -10,6 +10,9 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
         private readonly GitDirectoryInfo m_Parent;
         private readonly Blob m_Blob;
 
+
+        public GitId Commit => m_Parent.Commit;
+
         public override string Name { get; }
 
         public override string FullName

--- a/src/Extensions.Statiq.Git/Internal/GitObjectExtensions.cs
+++ b/src/Extensions.Statiq.Git/Internal/GitObjectExtensions.cs
@@ -1,0 +1,13 @@
+﻿using LibGit2Sharp;
+
+namespace Grynwald.Extensions.Statiq.Git.Internal
+{
+    public static class GitObjectExtensions
+    {
+        public static GitId GetGitId(this GitObject gitObject)
+        {
+            var sha = ((IBelongToARepository)gitObject).Repository.ObjectDatabase.ShortenObjectId(gitObject);
+            return new GitId(sha);
+        }
+    }
+}

--- a/src/Extensions.Statiq.Git/Internal/GitTag.cs
+++ b/src/Extensions.Statiq.Git/Internal/GitTag.cs
@@ -1,0 +1,42 @@
+﻿// Note: Adapted from https://github.com/ap0llo/changelog/blob/9c789d570199480801ea95d57f425b425b5f1964/src/ChangeLog/Git/GitTag.cs    
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Grynwald.Extensions.Statiq.Git.Internal
+{
+    public sealed class GitTag : IEquatable<GitTag>
+    {
+        public string Name { get; }
+
+        public GitId Commit { get; }
+
+
+        public GitTag(string name, GitId commit)
+        {
+            if (String.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(name));
+
+            Name = name;
+            Commit = commit;
+        }
+
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = StringComparer.Ordinal.GetHashCode(Name) * 397;
+                hash ^= Commit.GetHashCode();
+                return hash;
+            }
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as GitTag);
+
+        public bool Equals([AllowNull] GitTag other) =>
+            other != null &&
+            StringComparer.Ordinal.Equals(Name, other.Name) &&
+            Commit.Equals(other.Commit);
+    }
+}

--- a/src/Extensions.Statiq.Git/Internal/IGitRepository.cs
+++ b/src/Extensions.Statiq.Git/Internal/IGitRepository.cs
@@ -5,6 +5,11 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
 {
     public interface IGitRepository : IDisposable
     {
+        /// <summary>
+        /// Gets the repository's url. Can be a local path or a remote url.
+        /// </summary>
+        string Url { get; }
+
         RepositoryKind Kind { get; }
 
         string CurrentBranch { get; }

--- a/src/Extensions.Statiq.Git/Internal/IGitRepository.cs
+++ b/src/Extensions.Statiq.Git/Internal/IGitRepository.cs
@@ -11,6 +11,8 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
 
         IEnumerable<string> Branches { get; }
 
+        IEnumerable<GitTag> Tags { get; }
+
         GitId GetHeadCommitId(string branchName);
 
         GitDirectoryInfo GetRootDirectory(GitId commit);

--- a/src/Extensions.Statiq.Git/Internal/LocalGitRepository.cs
+++ b/src/Extensions.Statiq.Git/Internal/LocalGitRepository.cs
@@ -34,6 +34,7 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
             }
         }
 
+        public IEnumerable<GitTag> Tags => Repository.Tags.Select(tag => new GitTag(tag.FriendlyName, ToGitId(tag.Target)));
 
         public LocalGitRepository(string repositoryPath)
         {
@@ -48,8 +49,7 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
         public GitId GetHeadCommitId(string branchName)
         {
             var commit = Repository.Branches[branchName].Tip;
-            var id = Repository.ObjectDatabase.ShortenObjectId(commit);
-            return new GitId(id);
+            return ToGitId(commit);
         }
 
         public GitDirectoryInfo GetRootDirectory(GitId commitId)
@@ -65,5 +65,10 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
         }
 
 
+        private GitId ToGitId(GitObject gitObject)
+        {
+            var sha = Repository.ObjectDatabase.ShortenObjectId(gitObject);
+            return new GitId(sha);
+        }
     }
 }

--- a/src/Extensions.Statiq.Git/Internal/RemoteGitRepository.cs
+++ b/src/Extensions.Statiq.Git/Internal/RemoteGitRepository.cs
@@ -8,7 +8,6 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
 {
     public class RemoteGitRepository : IGitRepository
     {
-        private readonly string m_RemoteUrl;
         private TemporaryDirectory? m_RepositoryDirectory;
         private LocalGitRepository? m_LocalRepository;
 
@@ -22,7 +21,7 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
                     // clone repository into a new temporary directory
                     m_RepositoryDirectory?.Dispose();
                     m_RepositoryDirectory = new TemporaryDirectory();
-                    Repository.Clone(m_RemoteUrl, m_RepositoryDirectory, new CloneOptions() { IsBare = true });
+                    Repository.Clone(Url, m_RepositoryDirectory, new CloneOptions() { IsBare = true });
 
                     // create all remote branches as local branches
                     using var repository = new Repository(m_RepositoryDirectory);
@@ -50,6 +49,9 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
             }
         }
 
+
+        public string Url { get; }
+
         public string? RepositoryDirectory => m_RepositoryDirectory?.FullName;
 
         public RepositoryKind Kind => RepositoryKind.Remote;
@@ -66,7 +68,7 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
             if (String.IsNullOrWhiteSpace(remoteUrl))
                 throw new ArgumentException("Value must not be null or whitespace", nameof(remoteUrl));
 
-            m_RemoteUrl = remoteUrl;
+            Url = remoteUrl;
         }
 
 

--- a/src/Extensions.Statiq.Git/Internal/RemoteGitRepository.cs
+++ b/src/Extensions.Statiq.Git/Internal/RemoteGitRepository.cs
@@ -58,6 +58,7 @@ namespace Grynwald.Extensions.Statiq.Git.Internal
 
         public IEnumerable<string> Branches => LocalRepository.Branches;
 
+        public IEnumerable<GitTag> Tags => LocalRepository.Tags;
 
 
         public RemoteGitRepository(string remoteUrl)

--- a/src/Extensions.Statiq.Git/MetadataExtensions.cs
+++ b/src/Extensions.Statiq.Git/MetadataExtensions.cs
@@ -15,6 +15,11 @@ namespace Grynwald.Extensions.Statiq.Git
         public static string GetGitBranch(this IMetadata metadata) => metadata.GetString(GitKeys.GitBranch);
 
         /// <summary>
+        /// Gets the value for the <see cref="GitKeys.GitTag"/> key.
+        /// </summary>
+        public static string GetGitTag(this IMetadata metadata) => metadata.GetString(GitKeys.GitTag);
+
+        /// <summary>
         /// Gets the value for the <see cref="GitKeys.GitCommit"/> key.
         /// </summary>
         public static string GetGitCommit(this IMetadata metadata) => metadata.GetString(GitKeys.GitCommit);


### PR DESCRIPTION
In addition to git branches, extend the "ReadFileFromGit" module to allow reading files from a git repository's tags